### PR TITLE
Update defaultSetting with defaut rosbridge address

### DIFF
--- a/js/settings.controller.js
+++ b/js/settings.controller.js
@@ -19,8 +19,8 @@ angular.module('roscc')
         
         var defaultSetting = {
             name: 'New Setting',
-            address: '',
-            port: '',
+            address: location.hostname,
+            port: 9090,
             log: '/rosout', imagePreview: { port: 0, quality: 70, width: 640, height: 480 },
             battery: true,
             batteryTopic: ''


### PR DESCRIPTION
Hi,

Currently no address are provide as default, so the page stop loading and we cannot configure where  the WS server (rosbridge) is .
By using location.hostname as address we provide webserver addresse as default (usualy the same as ws server) and port 9090 is rosbridge default port !
