### PR TITLE
Adding the eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true,
+    		"modules": true
+        }
+    },
+    "rules": {
+        "semi": 2
+    }
+}


### PR DESCRIPTION
Using gulp returns errors due to JSLint configuration.

Adding the configuration (JSX & modules) remove the errors.

``` javascript
$ gulp
[11:48:33] Using gulpfile ~\Desktop\Workspace\Github\ros-control-center\gulpfile.js
[11:48:33] Starting 'js-lint'...
[11:48:34] Starting 'watch'...
[11:48:34] Finished 'watch' after 25 ms
[11:48:34]
C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\control\control.controller.js
  1:5  error  Parsing error: Unexpected token ros

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\helper\domains.service.js
  1:1  error  Parsing error: The keyword 'class' is reserved

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\helper\quaternions.service.js
  1:1  error  Parsing error: The keyword 'class' is reserved

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\navbar\navbar.directive.js
  5:15  error  Parsing error: Unexpected token (

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\parameters\parameters.directive.js
  6:15  error  Parsing error: Unexpected token (

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\services\service.directive.js
  6:15  error  Parsing error: Unexpected token (

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\settings\settings.controller.js
  1:1  error  Parsing error: The keyword 'class' is reserved

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\settings\settings.factory.js
  1:1  error  Parsing error: The keyword 'class' is reserved

C:\Users\paquesa\Desktop\Workspace\Github\ros-control-center\app\topics\topic.directive.js
  6:15  error  Parsing error: Unexpected token (

✖ 9 problems (9 errors, 0 warnings)

[11:48:34] 'js-lint' errored after 267 ms
[11:48:34] ESLintError in plugin 'gulp-eslint'
Message:
    Failed with 9 errors

```
